### PR TITLE
Add recipe for Python UDFs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ The cookbook is a living document. :seedling:
 ### Other Built-in Functions
 1. [Working with Dates and Timestamps](other-builtin-functions/01/01_date_time.md)
 
+### User-Defined Functions (UDFs)
+1. [Extending SQL with Python UDFs](udfs/01/01_python_udfs.md)
+
 ### Joins
 
 1. [Regular Joins](joins/01/01_regular_joins.md)

--- a/udfs/01/01_python_udfs.md
+++ b/udfs/01/01_python_udfs.md
@@ -1,0 +1,73 @@
+# 01 Extending SQL with Python UDFs
+
+:bulb: This example will show how to extend Flink SQL with custom functions written in Python.
+
+Flink SQL provides a wide range of [built-in functions](https://ci.apache.org/projects/flink/flink-docs-stable/dev/table/functions/systemFunctions.html) that cover most SQL day-to-day work. Sometimes, you need more flexibility to express custom business logic or transformations that aren't easily translatable to SQL: this can be achieved with [User-Defined Functions](https://ci.apache.org/projects/flink/flink-docs-stable/dev/table/functions/udfs.html) (UDFs).
+
+In this example, you'll focus on [Python UDFs](https://ci.apache.org/projects/flink/flink-docs-stable/dev/python/table-api-users-guide/udfs/python_udfs.html) and use them to deal with spotty temperature readings that are continuously generated. How would you interpolate the values for missed readings (i.e. `NULL`) to increase the accuracy of your results? One way to solve this is to write a Python function that uses [`pandas`](https://pandas.pydata.org/) to handle the interpolation.
+
+## Scripts
+
+#### Python UDF
+
+The first step is to create a Python file with the UDF implementation (`python_udf.py`), using Flink's [Python Table API](https://ci.apache.org/projects/flink/flink-docs-stable/dev/python/table-api-users-guide/intro_to_table_api.html). If this is new to you, there are examples on how to write [general](https://ci.apache.org/projects/flink/flink-docs-stable/dev/python/table-api-users-guide/udfs/python_udfs.html) and [vectorized](https://ci.apache.org/projects/flink/flink-docs-stable/dev/python/table-api-users-guide/udfs/vectorized_python_udfs.html) Python UDFs in the Flink documentation.
+
+```python
+from pyflink.table import DataTypes
+from pyflink.table.udf import udf
+
+import pandas as pd
+
+@udf(input_types=[DataTypes.STRING(), DataTypes.FLOAT()],
+     result_type=DataTypes.FLOAT(), func_type='pandas')
+def interpolate(id, temperature):
+    # takes id: pandas.Series and temperature: pandas.Series as input
+    df = pd.DataFrame({'id': id, 'temperature': temperature})
+
+    # use interpolate() to interpolate the missing temperature
+    interpolated_df = df.groupby('id').apply(
+        lambda group: group.interpolate(limit_direction='both'))
+
+    # output temperature: pandas.Series
+    return interpolated_df['temperature']
+```
+
+For detailed instructions on how to then make the Python file available as a UDF in the SQL Client, please refer to [this documentation page](https://ci.apache.org/projects/flink/flink-docs-stable/dev/table/sqlClient.html#user-defined-functions).
+
+#### SQL
+
+The source table (`temperature_measurements`) is backed by the [`faker` connector](https://github.com/knaufk/flink-faker), which continuously generates rows in memory based on Java Faker expressions. 
+
+```sql
+--Register the Python UDF using the fully qualified 
+--name of the function ([module name].[object name])
+CREATE FUNCTION interpolate AS 'python_udf.interpolate' 
+LANGUAGE PYTHON;
+
+
+CREATE TABLE temperature_measurements (
+  city STRING,
+  temperature FLOAT,
+  --Workaround to force NULLs
+  tmp AS NULLIF(temperature,35.0),
+  measurement_time AS PROCTIME()
+)
+WITH (
+  'connector' = 'faker',
+  'fields.temperature.expression' = '#{number.numberBetween ''0'',''42''}',
+  'fields.city.expression' = '#{regexify ''(Chicago|Munich|Berlin|Portland|Seattle|New York){1}''}'
+);
+
+
+--Use interpolate() to fill in missing temperature values
+SELECT city,
+       tmp,
+       interpolate(city,tmp) tmp_interpolated,
+       measurement_time
+FROM temperature_measurements
+WHERE city = 'Berlin';
+```
+
+## Example Output
+
+![01_python_udfs](https://user-images.githubusercontent.com/23521087/106631710-4d789e80-657d-11eb-86b9-e49c823ec8bb.gif)

--- a/udfs/01/01_python_udfs.md
+++ b/udfs/01/01_python_udfs.md
@@ -4,7 +4,7 @@
 
 Flink SQL provides a wide range of [built-in functions](https://ci.apache.org/projects/flink/flink-docs-stable/dev/table/functions/systemFunctions.html) that cover most SQL day-to-day work. Sometimes, you need more flexibility to express custom business logic or transformations that aren't easily translatable to SQL: this can be achieved with [User-Defined Functions](https://ci.apache.org/projects/flink/flink-docs-stable/dev/table/functions/udfs.html) (UDFs).
 
-In this example, you'll focus on [Python UDFs](https://ci.apache.org/projects/flink/flink-docs-stable/dev/python/table-api-users-guide/udfs/python_udfs.html) and use them to deal with spotty temperature readings that are continuously generated. How would you interpolate the values for missed readings (i.e. `NULL`) to increase the accuracy of your results? One way to solve this is to write a Python function that uses [`pandas`](https://pandas.pydata.org/) to handle the interpolation.
+In this example, you'll focus on [Python UDFs](https://ci.apache.org/projects/flink/flink-docs-stable/dev/python/table-api-users-guide/udfs/python_udfs.html) and implement a custom function (`to_fahr`) to convert temperature readings that are continuously generated for different EU and US cities. The Celsius->Fahrenheit conversion should only happen if the city associated with the reading is in the US.
 
 ## Scripts
 
@@ -16,20 +16,19 @@ The first step is to create a Python file with the UDF implementation (`python_u
 from pyflink.table import DataTypes
 from pyflink.table.udf import udf
 
-import pandas as pd
+us_cities = {"Chicago","Portland","Seattle","New York"}
 
 @udf(input_types=[DataTypes.STRING(), DataTypes.FLOAT()],
-     result_type=DataTypes.FLOAT(), func_type='pandas')
-def interpolate(id, temperature):
-    # takes id: pandas.Series and temperature: pandas.Series as input
-    df = pd.DataFrame({'id': id, 'temperature': temperature})
+     result_type=DataTypes.FLOAT())
+def to_fahr(city, temperature):
 
-    # use interpolate() to interpolate the missing temperature
-    interpolated_df = df.groupby('id').apply(
-        lambda group: group.interpolate(limit_direction='both'))
+  if city in us_cities:
 
-    # output temperature: pandas.Series
-    return interpolated_df['temperature']
+    fahr = ((temperature * 9.0 / 5.0) + 32.0)
+
+    return fahr
+  else:
+    return temperature
 ```
 
 For detailed instructions on how to then make the Python file available as a UDF in the SQL Client, please refer to [this documentation page](https://ci.apache.org/projects/flink/flink-docs-stable/dev/table/sqlClient.html#user-defined-functions).
@@ -41,33 +40,32 @@ The source table (`temperature_measurements`) is backed by the [`faker` connecto
 ```sql
 --Register the Python UDF using the fully qualified 
 --name of the function ([module name].[object name])
-CREATE FUNCTION interpolate AS 'python_udf.interpolate' 
+CREATE FUNCTION to_fahr AS 'python_udf.to_fahr' 
 LANGUAGE PYTHON;
 
 
 CREATE TABLE temperature_measurements (
   city STRING,
   temperature FLOAT,
-  --Workaround to force NULLs
-  tmp AS NULLIF(temperature,35.0),
-  measurement_time AS PROCTIME()
+  measurement_time TIMESTAMP(3),
+  WATERMARK FOR measurement_time AS measurement_time - INTERVAL '15' SECONDS
 )
 WITH (
   'connector' = 'faker',
   'fields.temperature.expression' = '#{number.numberBetween ''0'',''42''}',
-  'fields.city.expression' = '#{regexify ''(Chicago|Munich|Berlin|Portland|Seattle|New York){1}''}'
+  'fields.measurement_time.expression' = '#{date.past ''15'',''SECONDS''}',
+  'fields.city.expression' = '#{regexify ''(Copenhagen|Berlin|Chicago|Portland|Seattle|New York){1}''}'
 );
 
 
---Use interpolate() to fill in missing temperature values
+--Use to_fahr() to convert temperatures in US cities from C to F
 SELECT city,
-       tmp,
-       interpolate(city,tmp) tmp_interpolated,
+       temperature AS tmp,
+       to_fahr(city,temperature) AS tmp_conv,
        measurement_time
-FROM temperature_measurements
-WHERE city = 'Berlin';
+FROM temperature_measurements;
 ```
 
 ## Example Output
 
-![01_python_udfs](https://user-images.githubusercontent.com/23521087/106631710-4d789e80-657d-11eb-86b9-e49c823ec8bb.gif)
+![01_python_udfs](https://user-images.githubusercontent.com/23521087/106733744-8ca4ff00-6612-11eb-9721-e4a74fb07329.gif)

--- a/udfs/01/python_udf.py
+++ b/udfs/01/python_udf.py
@@ -1,0 +1,17 @@
+from pyflink.table import DataTypes
+from pyflink.table.udf import udf
+
+import pandas as pd
+
+@udf(input_types=[DataTypes.STRING(), DataTypes.FLOAT()],
+     result_type=DataTypes.FLOAT(), func_type='pandas')
+def interpolate(id, temperature):
+    # takes id: pandas.Series and temperature: pandas.Series as input
+    df = pd.DataFrame({'id': id, 'temperature': temperature})
+
+    # use interpolate() to interpolate the missing temperature
+    interpolated_df = df.groupby('id').apply(
+        lambda group: group.interpolate(limit_direction='both'))
+
+    # output temperature: pandas.Series
+    return interpolated_df['temperature']

--- a/udfs/01/python_udf.py
+++ b/udfs/01/python_udf.py
@@ -1,17 +1,16 @@
 from pyflink.table import DataTypes
 from pyflink.table.udf import udf
 
-import pandas as pd
+us_cities = {"Chicago","Portland","Seattle","New York"}
 
 @udf(input_types=[DataTypes.STRING(), DataTypes.FLOAT()],
-     result_type=DataTypes.FLOAT(), func_type='pandas')
-def interpolate(id, temperature):
-    # takes id: pandas.Series and temperature: pandas.Series as input
-    df = pd.DataFrame({'id': id, 'temperature': temperature})
+     result_type=DataTypes.FLOAT())
+def to_fahr(city, temperature):
 
-    # use interpolate() to interpolate the missing temperature
-    interpolated_df = df.groupby('id').apply(
-        lambda group: group.interpolate(limit_direction='both'))
+	if city in us_cities:
 
-    # output temperature: pandas.Series
-    return interpolated_df['temperature']
+		fahr = ((temperature * 9.0 / 5.0) + 32.0)
+
+		return fahr
+	else:
+		return temperature


### PR DESCRIPTION
🗒️ **Notes**

- Any suggestions on how to make the intermingling of PyFlink less confusing?
~~I initially intended to use event time and show how to deal with out-of-orderness, but it turned out to be more complicated than necessary for a basic example (i.e. would have to get into state and vectorization). I'd consider adding this in as an "advanced" example, but would just stick with processing time now for simplicity. What do you think?~~
- Does it make sense to create a new category, or would this fit better somewhere else? Taking into consideration future UDF-related recipes.
~~Is there a way to randomly introduce `NULL` values for a column using `faker`? I used a hack that just replaces a given temperature with `NULL`. Not important, but I'm curious if there's a better way to do this.~~

🦅 **TODO**

The SQL Client documentation page is not clear when it comes to using Python UDFs, as [this](https://stackoverflow.com/questions/62822456/apache-flink-1-11-unable-to-use-python-udf-in-sql-function-ddl) Stack Overflow question shows. Once the documentation freeze is over, I'd like to submit a PR to improve it.