### PR TITLE
Fix SQL typo

### DIFF
--- a/aggregations-and-analytics/01/01_group_by_window.md
+++ b/aggregations-and-analytics/01/01_group_by_window.md
@@ -30,7 +30,7 @@ CREATE TABLE server_logs (
   'fields.client_identity.expression' =  '-',
   'fields.userid.expression' =  '-',
   'fields.log_time.expression' =  '#{date.past ''15'',''5'',''SECONDS''}',
-  'fields.status_code.expression' = '#{regexify ''(200|201|204|400|401|403|301){1}''}',
+  'fields.status_code.expression' = '#{regexify ''(200|201|204|400|401|403|301){1}''}'
 );
 
 SELECT  


### PR DESCRIPTION
Fixes typo, otherwise following error is thrown:
```
[ERROR] Could not execute SQL statement. Reason:
org.apache.flink.sql.parser.impl.ParseException: Encountered ")" at line 15, column 1.
Was expecting one of:
    <BINARY_STRING_LITERAL> ...
    <QUOTED_STRING> ...
    <PREFIXED_STRING_LITERAL> ...
    <UNICODE_STRING_LITERAL> ...
    <BIG_QUERY_DOUBLE_QUOTED_STRING> ...
    <BIG_QUERY_QUOTED_STRING> ...
```