### PR TITLE
Added spell column to group by

### DIFF
--- a/aggregations-and-analytics/05_top_n/05_top_n.md
+++ b/aggregations-and-analytics/05_top_n/05_top_n.md
@@ -14,7 +14,7 @@ each spell a wizard has cast, we can maintain a continuous total of how many tim
 ```sql
 SELECT wizard, spell, COUNT(*) AS times_cast
 FROM spells_cast
-GROUP BY wizard;
+GROUP BY wizard, spell;
 ```
 
 This result can be used in an `OVER` window to calculate a [Top-N](https://docs.ververica.com/user_guide/sql_development/queries.html#top-n).


### PR DESCRIPTION
The group by clause does not have `spell` column which results in following error on executing the query:

```
[ERROR] Could not execute SQL statement. Reason:
org.apache.calcite.sql.validate.SqlValidatorException: Expression 'spell' is not being grouped
```