### PR TITLE
Added missing closing comment for sql hint

### DIFF
--- a/other-builtin-functions/04_override_table_options/04_override_table_options.md
+++ b/other-builtin-functions/04_override_table_options/04_override_table_options.md
@@ -50,7 +50,7 @@ SELECT * FROM `airports` /*+ OPTIONS('csv.ignore-parse-errors'='true') */ WHERE 
 You can apply SQL Hints for all possible table options. For example, if you SQL job which reads from Kafka has crashed, you can override the default reading position:
 
 ```sql
-SELECT * FROM `your_kafka_topic` /*+ OPTIONS('scan.startup.mode'='group-offsets');
+SELECT * FROM `your_kafka_topic` /*+ OPTIONS('scan.startup.mode'='group-offsets') */;
 ```
 
 Tables, views and functions are all registered in the catalog. The catalog is a collection of metadata. Using SQL Hints, you can override any defined metadata.  


### PR DESCRIPTION
The  [example](https://github.com/ververica/flink-sql-cookbook/blob/5360539c23d5841295b9f43ab0095ea85833d5f9/other-builtin-functions/04_override_table_options/04_override_table_options.md?plain=1#L53) <code>SELECT * FROM `your_kafka_topic` /*+ OPTIONS('scan.startup.mode'='group-offsets');</code> has missing closing comment for sql hint.